### PR TITLE
Added support for Local Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ template:
     # If you want to depend on a specific commit, branch or tag, you
     # can use a ref key.
     # ref: main
-  # Local path to the template (Not yet supported)
+  # Local path to the template
   # path: path/to/fd_template
   # List of the files or folders to copy from the template
   files:
@@ -65,7 +65,6 @@ dart pub global run fd_template_creator
 ## TODO
 
 * Custom path argument for the configuration file
-* Support local paths
 * Better error management
 
 ## Credits

--- a/example/fd_template.yaml
+++ b/example/fd_template.yaml
@@ -3,7 +3,7 @@ name: my_app
 # organization: com.example
 template:
   name: fd_template
-  # path: path/to/template
+  # path: ../fd_template_example
   git:
     url: https://github.com/Floating-Dartists/fd_template.git
     # ref: main

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -109,7 +109,22 @@ class CommandRunner {
         runInShell: true,
       );
     } else {
-      throw UnsupportedError('Only git repositories are supported for now.');
+      final result = io.Process.runSync(
+        'cp',
+        ['-r', templatePath!, 'temp'],
+        workingDirectory: workDir,
+        runInShell: true,
+      );
+      // Windows doesn't have the cp command, so we launch Powershell for our
+      // command in this case.
+      if (result.exitCode != 0) {
+        io.Process.runSync(
+          'powershell',
+          ['cp', '-r', templatePath, 'temp'],
+          workingDirectory: workDir,
+          runInShell: true,
+        );
+      }
     }
   }
 

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -109,18 +109,17 @@ class CommandRunner {
         runInShell: true,
       );
     } else {
-      final result = io.Process.runSync(
-        'cp',
-        ['-r', templatePath!, 'temp'],
-        workingDirectory: workDir,
-        runInShell: true,
-      );
-      // Windows doesn't have the cp command, so we launch Powershell for our
-      // command in this case.
-      if (result.exitCode != 0) {
+      if (io.Platform.isWindows) {
         io.Process.runSync(
           'powershell',
-          ['cp', '-r', templatePath, 'temp'],
+          ['cp', '-r', templatePath!, 'temp'],
+          workingDirectory: workDir,
+          runInShell: true,
+        );
+      } else {
+        io.Process.runSync(
+          'cp',
+          ['-r', templatePath!, 'temp'],
           workingDirectory: workDir,
           runInShell: true,
         );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fd_template_creator
 description:  A Dart script to generate a template for a Flutter project from a boilerplate code repository.
-version: 0.1.2+1
+version: 0.1.3+2
 homepage: https://github.com/Floating-Dartists/fd_template_creator
 environment:
   sdk: '>=2.16.1 <3.0.0'


### PR DESCRIPTION
As said in the title, added support for local paths for the template yaml file.

The method used is kind of hacky to work on Windows, as I check the exit code of the first CP attempt, and if it's different from 0, retry using powershell. 
It however doesn't create any problems if the command is executed twice (If for example, some Unix-based implementation of cp returns a nonzero code on a success). 